### PR TITLE
Fixing issue whereby clicks < THRESHOLD condition fails due to string comparisons as opposed to integer comparison. 

### DIFF
--- a/low_volume_skus.js
+++ b/low_volume_skus.js
@@ -24,7 +24,7 @@ var CUSTOM_LABEL_NR = '4';
 // above. Name this working sheet 'LowVolume'. Copy the link of the new sheet
 // and paste it below.
 var SPREADSHEET_URL =
-    'https://docs.google.com/spreadsheets/d/SPREADSHEET_ID';
+  'https://docs.google.com/spreadsheets/d/SPREADSHEET_ID';
 
 // Set the value for the label for newly flagged low volume products.
 var LABEL_LOW = 'low_clicks_last_30d';
@@ -46,8 +46,8 @@ var FILTER_NO_CLICKS = 'metrics.clicks < ' + THRESHOLD;
 // As a condition, it must have the previously added label and for ex. clicks
 // >50. To add further conditions use the AND clause, e.g. AND Conversions > 10.
 var FILTER_RAMPED_UP = 'metrics.clicks > ' + THRESHOLD +
-    ' AND segments.product_custom_attribute' + CUSTOM_LABEL_NR + ' LIKE "' +
-    LABEL_LOW + '" ';
+  ' AND segments.product_custom_attribute' + CUSTOM_LABEL_NR + ' LIKE "' +
+  LABEL_LOW + '" ';
 
 // To filter campaign names, add for ex. AND campaign.name LIKE “%FR_FR%”.
 // Set the filter to true to include it.
@@ -80,9 +80,9 @@ var COUNT_LIMIT = '10000';
 
 function main() {
   var productsNoClicks =
-      getFilteredShoppingProducts(FILTER_NO_CLICKS, checkLabel = false);
+    getFilteredShoppingProducts(FILTER_NO_CLICKS, checkLabel = false);
   var productsRampedUp =
-      getFilteredShoppingProducts(FILTER_RAMPED_UP, checkLabel = true);
+    getFilteredShoppingProducts(FILTER_RAMPED_UP, checkLabel = true);
   var products = productsNoClicks.concat(productsRampedUp);
   pushToSpreadsheet(products);
 }
@@ -105,11 +105,11 @@ function getFilteredShoppingProducts(filters, checkLabel) {
   };
 
   var query = 'SELECT segments.product_item_id, ' + campaignField + merchantIdField + labelField +
-      'metrics.clicks, metrics.impressions ' +
-      'FROM shopping_performance_view WHERE ' + filters +
-      ' AND segments.product_item_id != "undefined"' +
-      ' AND segments.date DURING ' + TIME_DURATION +
-      ' ORDER BY segments.product_item_id LIMIT ' + COUNT_LIMIT;
+    'metrics.clicks, metrics.impressions ' +
+    'FROM shopping_performance_view WHERE ' + filters +
+    ' AND segments.product_item_id != "undefined"' +
+    ' AND segments.date DURING ' + TIME_DURATION +
+    ' ORDER BY segments.product_item_id LIMIT ' + COUNT_LIMIT;
 
   var products = [];
   var count = 0;
@@ -119,11 +119,11 @@ function getFilteredShoppingProducts(filters, checkLabel) {
     var row = rows.next();
     var clicks = row['metrics.clicks'];
     var productId = (PRODUCT_ID_CAPITALISED) ?
-        row['segments.product_item_id'].toUpperCase() :
-        row['segments.product_item_id'];
+      row['segments.product_item_id'].toUpperCase() :
+      row['segments.product_item_id'];
 
     // Label product as low volume, if below threshold defined above.
-    if (clicks < THRESHOLD) {
+    if (parseInt(clicks) < parseInt(THRESHOLD)) {
       products.push([productId, LABEL_LOW]);
       count += 1;
 
@@ -137,7 +137,6 @@ function getFilteredShoppingProducts(filters, checkLabel) {
   return products;
 }
 
-
 function pushToSpreadsheet(data) {
   var spreadsheet = SpreadsheetApp.openByUrl(SPREADSHEET_URL);
   var sheet = spreadsheet.getSheetByName('LowVolume');
@@ -148,8 +147,8 @@ function pushToSpreadsheet(data) {
   var start_row = 2;
   var endRow = start_row + data.length - 1;
   var range = sheet.getRange(
-      'A' + start_row + ':' +
-      'B' + endRow);
+    'A' + start_row + ':' +
+    'B' + endRow);
   if (data.length > 0) {
     range.setValues(data);
   }

--- a/low_volume_skus.js
+++ b/low_volume_skus.js
@@ -46,8 +46,8 @@ var FILTER_NO_CLICKS = 'metrics.clicks < ' + THRESHOLD;
 // As a condition, it must have the previously added label and for ex. clicks
 // >50. To add further conditions use the AND clause, e.g. AND Conversions > 10.
 var FILTER_RAMPED_UP = 'metrics.clicks > ' + THRESHOLD +
-  ' AND segments.product_custom_attribute' + CUSTOM_LABEL_NR + ' LIKE "' +
-  LABEL_LOW + '" ';
+  ' AND segments.product_custom_attribute' + CUSTOM_LABEL_NR + ' LIKE "%' +
+  LABEL_LOW + '%" ';
 
 // To filter campaign names, add for ex. AND campaign.name LIKE “%FR_FR%”.
 // Set the filter to true to include it.

--- a/low_volume_skus_test.js
+++ b/low_volume_skus_test.js
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview This file contains tests & test data for low_volume_skus.
+ */
+
+let TEST_PASS_FAIL = { 'PASSED': 0, 'FAILED': 0, 'RAN': 0 };
+
+// Test Data based on customer experiences.
+const testData = [
+    {
+        'PRODUCT_ID_CAPITALISED': true,
+        'THRESHOLD': "10",
+        'metrics.clicks': "3",
+        'segments.product_item_id': 'abcd-12345'
+    },
+    {
+        'PRODUCT_ID_CAPITALISED': true,
+        'THRESHOLD': "20",
+        'metrics.clicks': "30",
+        'segments.product_item_id': 'efgh-67890'
+    }
+];
+
+const testCases = [
+    {
+        'id': 'test-clicks-less-than-threshold',
+        'want': {
+            'result_click': true,
+            'result_upper': 'ABCD-12345'
+        }
+    },
+    {
+        'id': 'test-clicks-more-than-threshold',
+        'want': {
+            'result_click': false,
+            'result_upper': 'EFGH-67890'
+        }
+    }
+]
+
+
+/**
+ * This function is used to test the output of getFilteredShoppingProducts
+ * @param {?object} testCases the test cases defined above.
+ * @param {?object} testData the data represented from an ads report query.
+ **/
+function test_getFilteredShoppingProducts(testCases, testData) {
+    var products = [];
+    var count = 0;
+    while (count < testData.length) {
+        var row = testData[count];
+        var testRow = testCases[count];
+        var PRODUCT_ID_CAPITALISED = row['PRODUCT_ID_CAPITALISED'];
+        var THRESHOLD = row['THRESHOLD'];
+        var clicks = row['metrics.clicks'];
+        var productId = (PRODUCT_ID_CAPITALISED) ?
+            row['segments.product_item_id'].toUpperCase() :
+            row['segments.product_item_id'];
+
+        // Label product as low volume, if below threshold defined above.
+        if (parseInt(clicks) < parseInt(THRESHOLD)) {
+            testOutput(testRow.id, true, testRow.want.result_click, 'result click unexpected value.')
+            testOutput(testRow.id, (productId == testRow.want.result_upper), true, 'result upper unexpected value.')
+            count += 1;
+            // Label product as ramped up, if it surpasses expected threshold.
+        } else {
+            testOutput(testRow.id, false, testRow.want.result_click, 'result click unexpected value')
+            testOutput(testRow.id, (productId == testRow.want.result_upper), true, 'result upper unexpected value.')
+            count += 1;
+        }
+    }
+}
+
+/**
+ * Run this first to begin test cases.
+ */
+function initTesting() {
+    // run test
+    test_getFilteredShoppingProducts(testCases, testData);
+
+    // Log test results
+    Logger.log(TEST_PASS_FAIL);
+}
+
+/**
+ * This function is used to test the output of a test. It will print the error
+ * if the test fails.
+ * @param {string} testCaseId the test case id (bug id) for tracking.
+ * @param {?object} actual the value that is present from the test.
+ * @param {?object} expected the expected value of the test.
+ * @param {string} errif the error that should be shown in logger upon failure.
+ *
+ * @return {!bool} if the test has successfully passed or not.
+ */
+function testOutput(testCaseId, actual, expected, errif) {
+    Logger.log(`Test - ${testCaseId}: ${actual == expected ? '++PASSED++' : '--FAILED--'}`);
+
+    // log error
+    if (actual != expected) {
+        TEST_PASS_FAIL['FAILED']++;
+        Logger.log(`Error:\n${errif}`);
+    } else {
+        TEST_PASS_FAIL['PASSED']++;
+    }
+
+    Logger.log(`Actual:\n${actual}`);
+    Logger.log(`Expected:\n${expected}`);
+
+    TEST_PASS_FAIL['RAN']++;
+
+    return (actual == expected);
+}


### PR DESCRIPTION
Fixing issue that was causing issues with my customer's solution. When looking at the typeof(clicks) and typeof(threshold) you'll see that both are listed as string values. Therefore, if you do a simple test such as the following:

```
var clicks = "3";
var threshold = "10";

return (clicks < threshold) 

// returns false, which shouldn't be the case.
```

This is due to line 126 comparison not converting the values to integer through parseInt. 

This pull request also has the following changes:

* Formatting
* Added test case / test file to confirm change works as expected
* Added %% wild card characters for a more refined LIKE on line 48. 